### PR TITLE
docs: fixed broken link README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Campers social site
 
 ## The beginning
-Using the instructions in the Moments walkthrough project, this project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app)
+Using the instructions in the Moments walkthrough project, this project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 The boilerplate code from Moments is the starting point of this project. 
 
 ## Available Scripts

--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
-<h1>Campers social site</h1>
+# Campers social site
 
-<h2>The beginning</h2>
-Using the instructions in the Moments walkthrough project, this project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
-
+## The beginning
+Using the instructions in the Moments walkthrough project, this project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app)
 The boilerplate code from Moments is the starting point of this project. 
-
-
-
 
 ## Available Scripts
 


### PR DESCRIPTION
I saw you had a broken link in your README.md, so I fixed it.

I updated the readme to use the markdown way of displaying headers instead of the html tags. This made the link work again.